### PR TITLE
Hide reorder option on mobile

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-album-display",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],

--- a/fs-album-display.html
+++ b/fs-album-display.html
@@ -238,7 +238,7 @@ Example:
         :host {
           padding-top:80px;
         }
-        .reorder {
+        .meta-controls .action.reorder {
           display: none;
         }
       }


### PR DESCRIPTION
It should've already been hidden, but the CSS was getting overridden

Fixes JIRA [PS-3717](https://almtools.ldschurch.org/fhjira/browse/PS-3717)